### PR TITLE
fix: failed to cross compile for windows

### DIFF
--- a/src/minilzo.rs
+++ b/src/minilzo.rs
@@ -2,7 +2,7 @@
 #![allow(warnings)]
 
 pub(crate) const LZO1X_1_MEM_COMPRESS: usize = 131072;
-pub(crate) type lzo_uint = ::std::os::raw::c_ulong;
+pub(crate) type lzo_uint = ::std::os::raw::c_ulonglong;
 extern "C" {
     pub fn __lzo_init_v2(
         arg1: ::std::os::raw::c_uint,


### PR DESCRIPTION
Lets assume you are in Linux environment and have installed Windows
mingw build tools.

When you build this lib using following command for Windows, it will fail.

    cargo build --release --target x86_64-pc-windows-gnu

Take one erorr as example

    error[E0308]: mismatched types
       --> src/lib.rs:143:17
        |
    143 |                 src.len() as u64,
        |                 ^^^^^^^^^^^^^^^^ expected `u32`, found `u64`
        |
    help: you can convert a `u64` to a `u32` and panic if the converted value doesn't fit

This is because this lib uses type `std::os::raw::c_ulong` which is not
necessary 64-bit width, see [here](https://doc.rust-lang.org/std/os/raw/type.c_ulong.html).
To ensure a width of 64-bit, change it to `std::os::raw::c_ulonglong`.